### PR TITLE
Define Context interface in the package

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Context is a copy of Context from the golang.org/x/net/context package.
-//type Context interface {
-//	context.Context
-//}
+type Context interface {
+	context.Context
+}
 
 // instanceContext is a context that provides only an instance id. It is
 // provided as the main background context.


### PR DESCRIPTION
Without defining Context it is not convenient to use, because the interface must be described.

This code would not be compiled, because `Context` is not defined.

``` go

import "github.com/m0sth8/context"

func m(ctx context.Context)
```

Importing original `context` package does not look like nice solution for me.
